### PR TITLE
Collect more data when a JavaScript error fires

### DIFF
--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -6,7 +6,9 @@ var JSErrorCollector = new function() {
         },
         pump: function() {
             var resp = [];
-            for (var i=0; i<list.length; ++i) {
+            var i = 0;
+            var ll = list.length;
+            for (; i < ll; i++) {
                 var scriptError = list[i];
                 resp[i] = {
                         errorCategory: scriptError.errorCategory,
@@ -21,11 +23,13 @@ var JSErrorCollector = new function() {
             return resp;
         },
         toString: function() {
-            var s = "";
-            for (var i=0; i<list.length; ++i) {
-                s += i + ": " + list[i] + "\n";
+            var s = [];
+            var i = 0;
+            var ll = list.length;
+            for (; i < ll; i++) {
+                s.push(i + ": " + list[i]);
             }
-            return s;
+            return s.length ? s.join("\n") + "\n" : "";
         }
     };
 
@@ -85,7 +89,9 @@ var JSErrorCollector_ErrorConsoleListener = {
                     var doc = fb.getPanel("console").document;
                     var logNodes = doc.querySelectorAll(".logRow .logContent span");
                     var consoleLines = [];
-                    for (var i=0; i<logNodes.length; ++i) {
+                    var i = 0;
+                    var ll = logNodes.length;
+                    for (; i < ll; i++) {
                         var logNode = logNodes[i];
                         if (!logNode.JSErrorCollector_extracted) {
                             consoleLines.push(logNodes[i].textContent);

--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -9,10 +9,11 @@ var JSErrorCollector = new function() {
             for (var i=0; i<list.length; ++i) {
                 var scriptError = list[i];
                 resp[i] = {
+                        errorCategory: scriptError.errorCategory,
                         errorMessage: scriptError.errorMessage,
                         sourceName: scriptError.sourceName,
                         lineNumber: scriptError.lineNumber,
-                        url: scriptError.url
+                        url: scriptError.sourceUrl,
                         console: scriptError.console
                         };
             }
@@ -80,7 +81,7 @@ var JSErrorCollector_ErrorConsoleListener = {
                 }
 
                 // We're just looking for content JS errors (see https://developer.mozilla.org/en/XPCOM_Interface_Reference/nsIScriptError#Categories)
-                if (errorCategory == "content javascript") {
+                if (scriptError.category == "content javascript") {
                     var consoleContent = null;
                     // try to get content from Firebug's console if it exists
                     try {
@@ -103,10 +104,11 @@ var JSErrorCollector_ErrorConsoleListener = {
                     }
 
                     var err = {
+                        errorCategory: scriptError.category,
                         errorMessage: scriptError.errorMessage,
                         sourceName: scriptError.sourceName,
                         lineNumber: scriptError.lineNumber,
-                        url: "gopher://actual.url.unknown/",
+                        sourceUrl: window.top.getBrowser().selectedBrowser.contentWindow.location.href,
                         console: consoleContent
                     };
                     console.log("collecting JS error", err)

--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -12,6 +12,7 @@ var JSErrorCollector = new function() {
                         errorMessage: scriptError.errorMessage,
                         sourceName: scriptError.sourceName,
                         lineNumber: scriptError.lineNumber,
+                        url: scriptError.url
                         console: scriptError.console
                         };
             }
@@ -37,8 +38,7 @@ var JSErrorCollector = new function() {
         var windowContent = window.getBrowser();
 
         var consoleService = Components.classes["@mozilla.org/consoleservice;1"].getService().QueryInterface(Components.interfaces.nsIConsoleService);
-        if (consoleService)
-        {
+        if (consoleService) {
             consoleService.registerListener(JSErrorCollector_ErrorConsoleListener);
         }
 
@@ -64,15 +64,11 @@ var JSErrorCollector = new function() {
 };
 
 //Error console listener
-var JSErrorCollector_ErrorConsoleListener =
-{
-    observe: function(consoleMessage)
-    {
-        if (document && consoleMessage)
-        {
+var JSErrorCollector_ErrorConsoleListener = {
+    observe: function(consoleMessage) {
+        if (document && consoleMessage) {
             // Try to convert the error to a script error
-            try
-            {
+            try {
                 var scriptError = consoleMessage.QueryInterface(Components.interfaces.nsIScriptError);
 
                 var errorCategory = scriptError.category;
@@ -84,14 +80,12 @@ var JSErrorCollector_ErrorConsoleListener =
                 }
 
                 // We're just looking for content JS errors (see https://developer.mozilla.org/en/XPCOM_Interface_Reference/nsIScriptError#Categories)
-                if (errorCategory == "content javascript")
-                {
+                if (errorCategory == "content javascript") {
                     var consoleContent = null;
                     // try to get content from Firebug's console if it exists
                     try {
                         if (window.Firebug && window.Firebug.currentContext) {
                             var doc = Firebug.currentContext.getPanel("console").document;
-//                          console.log("doc", doc.body.innerHTML, doc)
                             var logNodes = doc.querySelectorAll(".logRow .logContent span");
                             var consoleLines = [];
                             for (var i=0; i<logNodes.length; ++i) {
@@ -112,14 +106,14 @@ var JSErrorCollector_ErrorConsoleListener =
                         errorMessage: scriptError.errorMessage,
                         sourceName: scriptError.sourceName,
                         lineNumber: scriptError.lineNumber,
+                        url: "gopher://actual.url.unknown/",
                         console: consoleContent
                     };
                     console.log("collecting JS error", err)
                     JSErrorCollector.addError(err);
                 }
             }
-            catch (exception)
-            {
+            catch (exception) {
                 // ignore
             }
         }

--- a/firefox/content/overlay.js
+++ b/firefox/content/overlay.js
@@ -75,23 +75,20 @@ var JSErrorCollector_ErrorConsoleListener =
             {
                 var scriptError = consoleMessage.QueryInterface(Components.interfaces.nsIScriptError);
 
-                var errorCategory = scriptError.category;
-                var sourceName    = scriptError.sourceName;
-                if (sourceName) {
-                    if (sourceName.indexOf("about:") == 0 || sourceName.indexOf("chrome:") == 0) {
+                if (scriptError.sourceName) {
+                    if (scriptError.sourceName.indexOf("about:") == 0 || scriptError.sourceName.indexOf("chrome:") == 0) {
                         return; // not interested in internal errors
                     }
                 }
 
                 // We're just looking for content JS errors (see https://developer.mozilla.org/en/XPCOM_Interface_Reference/nsIScriptError#Categories)
-                if (errorCategory == "content javascript")
+                if (scriptError.errorCategory == "content javascript")
                 {
                     var consoleContent = null;
                     // try to get content from Firebug's console if it exists
                     try {
                         if (window.Firebug && window.Firebug.currentContext) {
                             var doc = Firebug.currentContext.getPanel("console").document;
-//                          console.log("doc", doc.body.innerHTML, doc)
                             var logNodes = doc.querySelectorAll(".logRow .logContent span");
                             var consoleLines = [];
                             for (var i=0; i<logNodes.length; ++i) {
@@ -110,8 +107,10 @@ var JSErrorCollector_ErrorConsoleListener =
 
                     var err = {
                         errorMessage: scriptError.errorMessage,
+                        errorCategory: scriptError.errorCategory,
                         sourceName: scriptError.sourceName,
                         lineNumber: scriptError.lineNumber,
+                        url: scriptError.sourceName,
                         console: consoleContent
                     };
                     console.log("collecting JS error", err)

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.8.2</version>
+            <scope>test</scope>
         </dependency>
         <!-- WebDriver -->
         <dependency>

--- a/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
+++ b/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
@@ -17,23 +17,37 @@ import org.openqa.selenium.firefox.FirefoxProfile;
  * @version $Revision:  $
  */
 public class JavaScriptError {
+	private final String errorCategory;
 	private final String errorMessage;
 	private final String sourceName;
-	private final int lineNumber;	
+	private final String url;
+	private final int lineNumber;
 	private final String console;
 
 	JavaScriptError(final Map<String, ? extends Object> map) {
+		errorCategory = (String) map.get("errorCategory");
 		errorMessage = (String) map.get("errorMessage");
 		sourceName = (String) map.get("sourceName");
+		url = (String) map.get("url");
 		lineNumber = ((Number) map.get("lineNumber")).intValue();
 		console = (String) map.get("console");
 	}
 
-	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console) {
+	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console, String url, String category) {
 		this.errorMessage = errorMessage;
 		this.sourceName = sourceName;
 		this.lineNumber = lineNumber;
 		this.console = console;
+		this.errorCategory = category;
+		this.url = url;
+	}
+
+	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console, String url) {
+		this(errorMessage, sourceName, lineNumber, console, url, "content javascript");
+	}
+
+	public String getErrorCategory() {
+		return errorCategory;
 	}
 
 	public String getErrorMessage() {
@@ -46,6 +60,10 @@ public class JavaScriptError {
 	
 	public String getSourceName() {
 		return sourceName;
+	}
+
+	public String getUrl() {
+		return url;
 	}
 	
 	/**
@@ -64,10 +82,12 @@ public class JavaScriptError {
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((errorCategory == null) ? 0 :errorCategory.hashCode());
 		result = prime * result + ((console == null) ? 0 : console.hashCode());
 		result = prime * result
 				+ ((errorMessage == null) ? 0 : errorMessage.hashCode());
 		result = prime * result + lineNumber;
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
 		result = prime * result
 				+ ((sourceName == null) ? 0 : sourceName.hashCode());
 		return result;
@@ -112,12 +132,26 @@ public class JavaScriptError {
 		} else if (!sourceName.equals(other.sourceName)) {
 			return false;
 		}
+		if (errorCategory == null) {
+			if (other.errorCategory != null) {
+				return false;
+			}
+		} else if (!errorCategory.equals(other.errorCategory)) {
+			return false;
+		}
+		if (url == null) {
+			if (other.url != null) {
+				return false;
+			}
+		} else if (!url.equals(other.url)) {
+			return false;
+		}
 		return true;
 	}
 
 	@Override
 	public String toString() {
-		String s = errorMessage + " [" + sourceName + ":" + lineNumber + "]";
+		String s = "[" + errorCategory + ":" + errorMessage + "]:[" + url + "][" + sourceName + ":" + lineNumber + "]";
 		if (console != null) {
 			s += "\nConsole: " + console;
 		}

--- a/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
+++ b/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
@@ -21,7 +21,6 @@ public class JavaScriptError {
 	private final String errorMessage;
 	private final String url;
 	private final String sourceName;
-	private final String url;
 	private final int lineNumber;
 	private final String console;
 
@@ -30,7 +29,6 @@ public class JavaScriptError {
 		errorMessage = (String) map.get("errorMessage");
 		url = (String) map.get("url");
 		sourceName = (String) map.get("sourceName");
-		url = (String) map.get("url");
 		lineNumber = ((Number) map.get("lineNumber")).intValue();
 		console = (String) map.get("console");
 	}
@@ -92,8 +90,6 @@ public class JavaScriptError {
 		result = prime * result + ((url == null) ? 0 : url.hashCode());
 		result = prime * result
 				+ ((sourceName == null) ? 0 : sourceName.hashCode());
-		result = prime * result + ((errorCategory == null) ? 0 : errorCategory.hashCode());
-		result = prime * result + ((url == null) ? 0 : url.hashCode());
 
 		return result;
 	}

--- a/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
+++ b/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
@@ -33,19 +33,6 @@ public class JavaScriptError {
 		console = (String) map.get("console");
 	}
 
-	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console, String url, String category) {
-		this.errorMessage = errorMessage;
-		this.sourceName = sourceName;
-		this.lineNumber = lineNumber;
-		this.console = console;
-		this.errorCategory = category;
-		this.url = url;
-	}
-
-	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console, String url) {
-		this(errorMessage, sourceName, lineNumber, console, url, "content javascript");
-	}
-
 	public String getErrorCategory() {
 		return errorCategory;
 	}
@@ -53,11 +40,11 @@ public class JavaScriptError {
 	public String getErrorMessage() {
 		return errorMessage;
 	}
-	
+
 	public int getLineNumber() {
 		return lineNumber;
 	}
-	
+
 	public String getSourceName() {
 		return sourceName;
 	}
@@ -65,10 +52,10 @@ public class JavaScriptError {
 	public String getUrl() {
 		return url;
 	}
-	
+
 	/**
 	 * If Firebug is installed and active, this will contain the content of the Firebug Console since
-	 * the previous JavaScript error. 
+	 * the previous JavaScript error.
 	 * @return
 	 */
 	public String getConsole() {
@@ -172,7 +159,7 @@ public class JavaScriptError {
 		for (final Object rawError : errors) {
 			response.add(new JavaScriptError((Map<String, ? extends Object>) rawError));
 		}
-		
+
 		return response;
 	}
 

--- a/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
+++ b/src/main/java/net/jsourcerer/webdriver/jserrorcollector/JavaScriptError.java
@@ -17,23 +17,33 @@ import org.openqa.selenium.firefox.FirefoxProfile;
  * @version $Revision:  $
  */
 public class JavaScriptError {
+	private final String errorCategory;
 	private final String errorMessage;
+	private final String url;
 	private final String sourceName;
 	private final int lineNumber;	
 	private final String console;
 
 	JavaScriptError(final Map<String, ? extends Object> map) {
+		errorCategory = (String) map.get("errorCategory");
 		errorMessage = (String) map.get("errorMessage");
+		url = (String) map.get("url");
 		sourceName = (String) map.get("sourceName");
 		lineNumber = ((Number) map.get("lineNumber")).intValue();
 		console = (String) map.get("console");
 	}
 
-	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console) {
+	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console, String url, String errorCategory) {
 		this.errorMessage = errorMessage;
 		this.sourceName = sourceName;
 		this.lineNumber = lineNumber;
 		this.console = console;
+		this.url = url;
+		this.errorCategory = errorCategory;
+	}
+
+	JavaScriptError(final String errorMessage, final String sourceName, final int lineNumber, String console, String url) {
+		this(errorMessage, sourceName, lineNumber, console, url, "content javascript");
 	}
 
 	public String getErrorMessage() {
@@ -46,6 +56,14 @@ public class JavaScriptError {
 	
 	public String getSourceName() {
 		return sourceName;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public String getErrorCategory() {
+		return errorCategory;
 	}
 	
 	/**
@@ -70,6 +88,9 @@ public class JavaScriptError {
 		result = prime * result + lineNumber;
 		result = prime * result
 				+ ((sourceName == null) ? 0 : sourceName.hashCode());
+		result = prime * result + ((errorCategory == null) ? 0 : errorCategory.hashCode());
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
+
 		return result;
 	}
 
@@ -112,12 +133,26 @@ public class JavaScriptError {
 		} else if (!sourceName.equals(other.sourceName)) {
 			return false;
 		}
+		if (errorCategory == null) {
+			if (other.errorCategory != null) {
+				return false;
+			}
+		} else if (!errorCategory.equals(other.errorCategory)) {
+			return false;
+		}
+		if (url == null) {
+			if (other.url != null) {
+				return false;
+			}
+		} else if (!url.equals(other.url)) {
+			return false;
+		}
 		return true;
 	}
 
 	@Override
 	public String toString() {
-		String s = errorMessage + " [" + sourceName + ":" + lineNumber + "]";
+		String s = errorCategory + ":" + errorMessage + " [" + url + ":" + sourceName + ":" + lineNumber + "]";
 		if (console != null) {
 			s += "\nConsole: " + console;
 		}

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/ErrorBuilder.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/ErrorBuilder.java
@@ -40,12 +40,23 @@ public class ErrorBuilder {
         return this;
     }
 
+    public ErrorBuilder columnNumber(int columnNumber) {
+        data.put("columnNumber", columnNumber);
+        return this;
+    }
+
     public ErrorBuilder console(String console) {
         data.put("console", console);
         return this;
     }
 
     public JavaScriptError build() {
+        data.put("stack", String.format("@%s:%s:%s", data.get("sourceName"), data.get("lineNumber"), data.get("columnNumber")));
+        return new JavaScriptError(data);
+    }
+
+    public JavaScriptError buildWithStack(final String stack) {
+        data.put("stack", stack);
         return new JavaScriptError(data);
     }
 }

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/ErrorBuilder.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/ErrorBuilder.java
@@ -1,0 +1,51 @@
+package net.jsourcerer.webdriver.jserrorcollector;
+
+import com.google.common.collect.Maps;
+
+import java.util.Map;
+
+public class ErrorBuilder {
+    private final Map<String,Object> data;
+
+    public ErrorBuilder() {
+        this.data = Maps.newHashMap();
+    }
+
+    public ErrorBuilder errorCategory(String errorCategory) {
+        data.put("errorCategory", errorCategory);
+        return this;
+    }
+
+    public ErrorBuilder errorMessage(String errorMessage) {
+        data.put("errorMessage", errorMessage);
+        return this;
+    }
+
+    public ErrorBuilder source(String url) {
+        data.put("sourceName", url);
+        return this;
+    }
+
+    public ErrorBuilder url(String url) {
+        data.put("url", url);
+        return this;
+    }
+
+    public ErrorBuilder sourceAndUrl(String sourceName) {
+        return source(sourceName).url(sourceName);
+    }
+
+    public ErrorBuilder lineNumber(int lineNumber) {
+        data.put("lineNumber", lineNumber);
+        return this;
+    }
+
+    public ErrorBuilder console(String console) {
+        data.put("console", console);
+        return this;
+    }
+
+    public JavaScriptError build() {
+        return new JavaScriptError(data);
+    }
+}

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/FirebugConsoleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/FirebugConsoleTest.java
@@ -57,9 +57,14 @@ public class FirebugConsoleTest {
 	public void simple() throws Exception {
 		final String url = getResource("withConsoleOutput.html");
 		webDriver.get(url);
-		
-		final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", url, 8, "before JS error", url);
-		
+
+		final JavaScriptError errorSimpleHtml = new ErrorBuilder()
+				.errorMessage("TypeError: null has no properties")
+				.sourceAndUrl(url)
+				.lineNumber(8)
+				.console("before JS error")
+				.build();
+
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
 		List<JavaScriptError> jsErrors = JavaScriptError.readErrors(webDriver);
 		assertEquals(expectedErrors, jsErrors);

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/FirebugConsoleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/FirebugConsoleTest.java
@@ -56,7 +56,7 @@ public class FirebugConsoleTest {
 		final String url = getResource("withConsoleOutput.html");
 		webDriver.get(url);
 
-		final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", url, 8, "before JS error");
+		final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", url, 8, "before JS error", "idk");
 		
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
 		List<JavaScriptError> jsErrors = JavaScriptError.readErrors(webDriver);

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/FirebugConsoleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/FirebugConsoleTest.java
@@ -39,6 +39,8 @@ public class FirebugConsoleTest {
 		ffProfile.setPreference("extensions.firebug.throttleMessages", false);
 		ffProfile.setPreference("extensions.firebug.console.enableSites", true);
 		ffProfile.setPreference("extensions.firebug.defaultPanelName", "console");
+		
+		ffProfile.setPreference("extensions.JSErrorCollector.console.logLevel", "all");
 
 		webDriver = new FirefoxDriver(ffProfile);
 	}
@@ -56,7 +58,7 @@ public class FirebugConsoleTest {
 		final String url = getResource("withConsoleOutput.html");
 		webDriver.get(url);
 
-		final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", url, 8, "before JS error");
+		final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", url, 8, "before JS error", url);
 		
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
 		List<JavaScriptError> jsErrors = JavaScriptError.readErrors(webDriver);

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
@@ -122,6 +122,7 @@ public class SimpleTest {
 
 	WebDriver buildFFDriver() throws IOException {
 		FirefoxProfile ffProfile = new FirefoxProfile();
+		ffProfile.setPreference("extensions.JSErrorCollector.console.logLevel", "all");
 		ffProfile.addExtension(new File("firefox")); // assuming that the test is started in project's root
 
 		return new FirefoxDriver(ffProfile);

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
@@ -30,25 +30,26 @@ public class SimpleTest {
 			.errorMessage("TypeError: null has no properties")
 			.sourceAndUrl(urlSimpleHtml)
 			.lineNumber(9)
+			.columnNumber(1)
 			.errorCategory(EX)
 			.build();
 
 	private final String urlWithNestedFrameHtml = getResource("withNestedFrame.html");
-	private final JavaScriptError errorWithNestedFrameHtml = new ErrorBuilder().errorMessage("TypeError: \"foo\".notHere is not a function").sourceAndUrl(urlWithNestedFrameHtml).lineNumber(7).errorCategory(EX).build();
-	private final JavaScriptError errorInNestedFrame = new ErrorBuilder().errorMessage("TypeError: null has no properties").source(urlSimpleHtml).url(urlWithNestedFrameHtml).lineNumber(9).errorCategory(EX).build();
+	private final JavaScriptError errorWithNestedFrameHtml = new ErrorBuilder().errorMessage("TypeError: \"foo\".notHere is not a function").sourceAndUrl(urlWithNestedFrameHtml).lineNumber(7).columnNumber(1).errorCategory(EX).build();
+	private final JavaScriptError errorInNestedFrame = new ErrorBuilder().errorMessage("TypeError: null has no properties").source(urlSimpleHtml).url(urlWithNestedFrameHtml).lineNumber(9).columnNumber(1).errorCategory(EX).build();
 
 	private final String urlWithPopupHtml = getResource("withPopup.html");
 	private final String urlPopupHtml = getResource("popup.html");
-	private final JavaScriptError errorPopupHtml = new ErrorBuilder().errorMessage("ReferenceError: error is not defined").source(urlPopupHtml).url(urlWithPopupHtml).lineNumber(5).errorCategory(EX).build();
+	private final JavaScriptError errorPopupHtml = new ErrorBuilder().errorMessage("ReferenceError: error is not defined").source(urlPopupHtml).url(urlWithPopupHtml).lineNumber(5).columnNumber(3).errorCategory(EX).build();
 
 	private final String urlWithExternalJs = getResource("withExternalJs.html");
 	private final String urlExternalJs = getResource("external.js");
-	private final JavaScriptError errorExternalJs = new ErrorBuilder().errorMessage("TypeError: document.notExisting is undefined").source(urlExternalJs).url(urlWithExternalJs).lineNumber(1).errorCategory(EX).build();
+	private final JavaScriptError errorExternalJs = new ErrorBuilder().errorMessage("TypeError: document.notExisting is undefined").source(urlExternalJs).url(urlWithExternalJs).lineNumber(1).columnNumber(1).errorCategory(EX).build();
 
 	private final String urlThrowing = getResource("throwing.html");
-	private final JavaScriptError errorThrowingErrorObject = new ErrorBuilder().errorMessage("Error: an explicit error object!").sourceAndUrl(urlThrowing).lineNumber(9).errorCategory(EX).build();
-	private final JavaScriptError errorThrowingPlainObject = new ErrorBuilder().errorMessage("uncaught exception: a plain JS object!").url(urlThrowing).lineNumber(0).errorCategory(ERR).build();
-	private final JavaScriptError errorThrowingString = new ErrorBuilder().errorMessage("uncaught exception: a string error!").url(urlThrowing).lineNumber(0).errorCategory(ERR).build();
+	private final JavaScriptError errorThrowingErrorObject = new ErrorBuilder().errorMessage("Error: an explicit error object!").sourceAndUrl(urlThrowing).lineNumber(9).columnNumber(11).errorCategory(EX).build();
+	private final JavaScriptError errorThrowingPlainObject = new ErrorBuilder().errorMessage("uncaught exception: a plain JS object!").url(urlThrowing).lineNumber(0).columnNumber(0).errorCategory(ERR).buildWithStack("undefined");
+	private final JavaScriptError errorThrowingString = new ErrorBuilder().errorMessage("uncaught exception: a string error!").url(urlThrowing).lineNumber(0).columnNumber(0).errorCategory(ERR).buildWithStack("undefined");
 
 	private WebDriver driver;
 

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
@@ -21,23 +21,24 @@ import static org.junit.Assert.assertEquals;
  */
 public class SimpleTest {
 	private final String urlSimpleHtml = getResource("simple.html");
-	private final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9, null);
+	private final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9, null, urlSimpleHtml);
 	
 	private final String urlWithNestedFrameHtml = getResource("withNestedFrame.html");
-	private final JavaScriptError errorWithNestedFrameHtml = new JavaScriptError("TypeError: \"foo\".notHere is not a function", urlWithNestedFrameHtml, 7, null);
+	private final JavaScriptError errorWithNestedFrameHtml = new JavaScriptError("TypeError: \"foo\".notHere is not a function", urlWithNestedFrameHtml, 7, null, urlWithNestedFrameHtml);
+	private final JavaScriptError errorInNestedFrame = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9, null, urlWithNestedFrameHtml);
 
 	private final String urlWithPopupHtml = getResource("withPopup.html");
 	private final String urlPopupHtml = getResource("popup.html");
-	private final JavaScriptError errorPopupHtml = new JavaScriptError("ReferenceError: error is not defined", urlPopupHtml, 5, null);
+	private final JavaScriptError errorPopupHtml = new JavaScriptError("ReferenceError: error is not defined", urlPopupHtml, 5, null, urlWithPopupHtml);
 
 	private final String urlWithExternalJs = getResource("withExternalJs.html");
 	private final String urlExternalJs = getResource("external.js");
-	private final JavaScriptError errorExternalJs = new JavaScriptError("TypeError: document.notExisting is undefined", urlExternalJs, 1, null);
+	private final JavaScriptError errorExternalJs = new JavaScriptError("TypeError: document.notExisting is undefined", urlExternalJs, 1, null, urlWithExternalJs);
 
 	private final String urlThrowing = getResource("throwing.html");
-	private final JavaScriptError errorThrowingErrorObject = new JavaScriptError("Error: an explicit error object!", urlThrowing, 9, null);
-	private final JavaScriptError errorThrowingPlainObject = new JavaScriptError("uncaught exception: a plain JS object!", "", 0, null);
-	private final JavaScriptError errorThrowingString = new JavaScriptError("uncaught exception: a string error!", "", 0, null);
+	private final JavaScriptError errorThrowingErrorObject = new JavaScriptError("Error: an explicit error object!", urlThrowing, 9, null, urlThrowing);
+	private final JavaScriptError errorThrowingPlainObject = new JavaScriptError("uncaught exception: a plain JS object!", "", 0, null, urlThrowing);
+	private final JavaScriptError errorThrowingString = new JavaScriptError("uncaught exception: a string error!", "", 0, null, urlThrowing);
 
 	/**
 	 *
@@ -45,13 +46,16 @@ public class SimpleTest {
 	@Test
 	public void simple() throws Exception {
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlSimpleHtml);
-		
-		final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors, jsErrors);
-		
-		driver.quit();
+
+		try {
+			driver.get(urlSimpleHtml);
+			
+			final List<JavaScriptError> expectedErrors = Arrays.asList(errorSimpleHtml);
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors, jsErrors);
+		} finally {
+			driver.quit();	
+		}
 	}
 	
 	/**
@@ -59,15 +63,17 @@ public class SimpleTest {
 	 */
 	@Test
 	public void errorInNestedFrame() throws Exception {
-		final List<JavaScriptError> expectedErrors = Arrays.asList(errorWithNestedFrameHtml, errorSimpleHtml);
-
+		final List<JavaScriptError> expectedErrors = Arrays.asList(errorWithNestedFrameHtml, errorInNestedFrame);
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlWithNestedFrameHtml);
 		
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
-
-		driver.quit();
+		try {
+			driver.get(urlWithNestedFrameHtml);
+			
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		} finally {
+			driver.quit();
+		}
 	}
 	
 	/**
@@ -78,13 +84,16 @@ public class SimpleTest {
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorPopupHtml);
 
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlWithPopupHtml);
-		driver.findElement(By.tagName("button")).click();
+		try {
+			driver.get(urlWithPopupHtml);
+			driver.findElement(By.tagName("button")).click();
 
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		} finally {
+			driver.quit();
+		}
 		
-		driver.quit();
 	}
 
 	/**
@@ -95,12 +104,15 @@ public class SimpleTest {
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorExternalJs);
 
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlWithExternalJs);
+		try {
+			driver.get(urlWithExternalJs);
 
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		} finally {
+			driver.quit();
+		}
 		
-		driver.quit();
 	}
 
 	/**
@@ -111,12 +123,15 @@ public class SimpleTest {
 		final List<JavaScriptError> expectedErrors = Arrays.asList(errorThrowingErrorObject, errorThrowingPlainObject, errorThrowingString);
 
 		final WebDriver driver = buildFFDriver();
-		driver.get(urlThrowing);
+		try {
+			driver.get(urlThrowing);
 
-		final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
-		assertEquals(expectedErrors.toString(), jsErrors.toString());
+			final List<JavaScriptError> jsErrors = JavaScriptError.readErrors(driver);
+			assertEquals(expectedErrors.toString(), jsErrors.toString());
+		} finally {
+			driver.quit();
+		}
 
-		driver.quit();
 	}
 
 

--- a/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
+++ b/src/test/java/net/jsourcerer/webdriver/jserrorcollector/SimpleTest.java
@@ -21,23 +21,23 @@ import static org.junit.Assert.assertEquals;
  */
 public class SimpleTest {
 	private final String urlSimpleHtml = getResource("simple.html");
-	private final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9, null);
+	private final JavaScriptError errorSimpleHtml = new JavaScriptError("TypeError: null has no properties", urlSimpleHtml, 9, null, "idk");
 	
 	private final String urlWithNestedFrameHtml = getResource("withNestedFrame.html");
-	private final JavaScriptError errorWithNestedFrameHtml = new JavaScriptError("TypeError: \"foo\".notHere is not a function", urlWithNestedFrameHtml, 7, null);
+	private final JavaScriptError errorWithNestedFrameHtml = new JavaScriptError("TypeError: \"foo\".notHere is not a function", urlWithNestedFrameHtml, 7, null, "idk");
 
 	private final String urlWithPopupHtml = getResource("withPopup.html");
 	private final String urlPopupHtml = getResource("popup.html");
-	private final JavaScriptError errorPopupHtml = new JavaScriptError("ReferenceError: error is not defined", urlPopupHtml, 5, null);
+	private final JavaScriptError errorPopupHtml = new JavaScriptError("ReferenceError: error is not defined", urlPopupHtml, 5, null, "idk");
 
 	private final String urlWithExternalJs = getResource("withExternalJs.html");
 	private final String urlExternalJs = getResource("external.js");
-	private final JavaScriptError errorExternalJs = new JavaScriptError("TypeError: document.notExisting is undefined", urlExternalJs, 1, null);
+	private final JavaScriptError errorExternalJs = new JavaScriptError("TypeError: document.notExisting is undefined", urlExternalJs, 1, null, "idk");
 
 	private final String urlThrowing = getResource("throwing.html");
-	private final JavaScriptError errorThrowingErrorObject = new JavaScriptError("Error: an explicit error object!", urlThrowing, 9, null);
-	private final JavaScriptError errorThrowingPlainObject = new JavaScriptError("uncaught exception: a plain JS object!", "", 0, null);
-	private final JavaScriptError errorThrowingString = new JavaScriptError("uncaught exception: a string error!", "", 0, null);
+	private final JavaScriptError errorThrowingErrorObject = new JavaScriptError("Error: an explicit error object!", urlThrowing, 9, null, "idk");
+	private final JavaScriptError errorThrowingPlainObject = new JavaScriptError("uncaught exception: a plain JS object!", "", 0, null, "idk");
+	private final JavaScriptError errorThrowingString = new JavaScriptError("uncaught exception: a string error!", "", 0, null, "idk");
 
 	/**
 	 *


### PR DESCRIPTION
This will record additional details available through Firefox's XCOM interface, including:

* The category of problem (typically Exception, Error, or Info),
* The URL of the page that generated the error,
* The column number of the error (useful for minified files!), and
* (If available) the stack trace of the error.

